### PR TITLE
Dev/fix close and load calls

### DIFF
--- a/library/js/popup-close.js
+++ b/library/js/popup-close.js
@@ -9,12 +9,12 @@
 
 	HUI.popupClose = function( el ) {
 
-		const close = $( el );
-		const popup = close.closest( '.hustle-ui' );
-		const overlay = popup.find( '.hustle-popup-mask' );
-		const content = popup.find( '.hustle-popup-content' );
+		const popup = $( el ),
+			close = popup.find( '.hustle-button-close' ),
+			overlay = popup.find( '.hustle-popup-mask' ),
+			content = popup.find( '.hustle-popup-content' );
 
-		if ( ! close.is( '.hustle-button-close' ) ) {
+		if ( ! close.length ) {
 			return;
 		}
 

--- a/library/js/popup-load.js
+++ b/library/js/popup-load.js
@@ -79,20 +79,12 @@
 				animationIn();
 			}, layoutTime );
 
+			HUI.popupClose( el );
 		}
 
 		init();
 
 		return this;
 	};
-
-	$( '.hustle-popup' ).each( function() {
-
-		const popup = $( this );
-		const delay = $( this ).data( 'delay' );
-
-		HUI.popupLoad( popup, delay );
-
-	});
 
 }( jQuery ) );

--- a/library/js/slidein-close.js
+++ b/library/js/slidein-close.js
@@ -9,11 +9,11 @@
 
 	HUI.slideinClose = function( el ) {
 
-		const close = $( el );
-		const slidein = close.closest( '.hustle-ui' );
-		const content = slidein.find( '.hustle-slidein-content' );
+		const slidein = $( el ),
+			close = slidein.find( '.hustle-button-close' ),
+			content = slidein.find( '.hustle-slidein-content' );
 
-		if ( ! close.is( '.hustle-button-close' ) ) {
+		if ( ! close.length ) {
 			return;
 		}
 

--- a/library/js/slidein-load.js
+++ b/library/js/slidein-load.js
@@ -98,13 +98,4 @@
 		return this;
 	};
 
-	$( '.hustle-slidein' ).each( function() {
-
-		const slidein = $( this );
-		const delay = $( this ).data( 'delay' );
-
-		HUI.slideinLoad( slidein, delay );
-
-	});
-
 }( jQuery ) );

--- a/library/js/slidein-load.js
+++ b/library/js/slidein-load.js
@@ -90,6 +90,7 @@
 				animation();
 			}, layoutTime );
 
+			HUI.slideinClose( el );
 		}
 
 		init();


### PR DESCRIPTION
-Prevent slideins and popups from showing up on page load.
-Attach closing actions when the module is loaded, not on page load.
Task: https://app.asana.com/0/1103916574828896/1106379536961623/f