### PR TITLE
Add frontend validation as a separate function

### DIFF
--- a/library/js/optin-simulation.js
+++ b/library/js/optin-simulation.js
@@ -26,50 +26,6 @@
 			error.hide();
 		}
 
-		function resetOnClick() {
-
-			const input = form.find( '.hustle-field' );
-			const checkbox = form.find( '.hustle-checkbox' );
-
-			input.removeClass( 'hustle-field-error' );
-			checkbox.removeClass( 'hustle-field-error' );
-			error.hide();
-
-		}
-
-		function checkGdpr() {
-
-			const label = form.find( '.hustle-gdpr' );
-			const input = label.find( 'input' );
-
-			if ( input.is( ':checked' ) ) {
-				label.removeClass( 'hustle-field-error' );
-			} else {
-				label.addClass( 'hustle-field-error' );
-			}
-		}
-
-		function checkRequired() {
-
-			const input = form.find( '.hustle-input' );
-			const label = input.parent();
-
-			label.each( function() {
-
-				const field = $( this );
-
-				if ( field.hasClass( 'hustle-field-required' ) ) {
-
-					if ( '' === field.find( 'input' ).val() ) {
-						field.addClass( 'hustle-field-error' );
-					} else {
-						field.removeClass( 'hustle-field-error' );
-					}
-				}
-			});
-
-		}
-
 		function init() {
 
 			resetOnLoad();
@@ -82,8 +38,7 @@
 
 				setTimeout( function() {
 
-					checkGdpr();
-					checkRequired();
+					HUI.optinValidate( module );
 
 					if ( form.find( '.hustle-field-error' ).length ) {
 						HUI.optinError( error );

--- a/library/js/optin-validate.js
+++ b/library/js/optin-validate.js
@@ -1,0 +1,72 @@
+( function( $ ) {
+
+	'use strict';
+
+	// Define global HUI object if it doesn't exist.
+	if ( 'object' !== typeof window.HUI ) {
+		window.HUI = {};
+	}
+
+	HUI.optinValidate = function( el ) {
+
+		const module = $( el ),
+			form = module.find( '.hustle-layout-form' );
+
+		function resetOnClick() {
+
+			const input = form.find( '.hustle-field' ),
+				checkbox = form.find( '.hustle-checkbox' ),
+				error = form.find( '.hustle-error-message' );
+
+			input.removeClass( 'hustle-field-error' );
+			checkbox.removeClass( 'hustle-field-error' );
+			error.hide();
+
+		}
+
+		function checkGdpr() {
+
+			const label = form.find( '.hustle-gdpr' ),
+				input = label.find( 'input' );
+
+			if ( input.is( ':checked' ) ) {
+				label.removeClass( 'hustle-field-error' );
+			} else {
+				label.addClass( 'hustle-field-error' );
+			}
+		}
+
+		function checkRequired() {
+
+			const input = form.find( '.hustle-input' );
+			const label = input.parent();
+
+			label.each( function() {
+
+				const field = $( this );
+
+				if ( field.hasClass( 'hustle-field-required' ) ) {
+
+					if ( '' === field.find( 'input' ).val() ) {
+						field.addClass( 'hustle-field-error' );
+					} else {
+						field.removeClass( 'hustle-field-error' );
+					}
+				}
+			});
+		}
+
+		function init() {
+
+			resetOnClick();
+
+			checkGdpr();
+			checkRequired();
+		}
+
+		init();
+
+		return this;
+	};
+
+}( jQuery ) );


### PR DESCRIPTION
-Add frontend validation as a separate function. This way we can also use it on hustle's side before doing the ajax call.
-Change optin-simulation validation to use this new function instead.
Task: https://app.asana.com/0/1103916574828896/1107904364768520/f