### PR TITLE
Fix calling the close function with 0 delay does nothing

### DIFF
--- a/library/js/popup-close.js
+++ b/library/js/popup-close.js
@@ -96,7 +96,7 @@
 				preventAutohide = true;
 			});
 
-			if ( autohideDelay ) {
+			if ( 'undefined' !== typeof autohideDelay && false !== autohideDelay ) {
 
 				setTimeout( function() {
 

--- a/library/js/slidein-close.js
+++ b/library/js/slidein-close.js
@@ -39,7 +39,7 @@
 				preventAutohide = true;
 			});
 
-			if ( autohideDelay ) {
+			if ( 'undefined' !== typeof autohideDelay && false !== autohideDelay ) {
 
 				setTimeout( function() {
 


### PR DESCRIPTION
We were checking checking `if ( autohideDelay  ) { close the popup/slidein after the delay }` . So if the delay is 0, it's evaluated as false and nothing happened.