### PR TITLE
Fix/modules showing unstyled

### DIFF
--- a/library/js/float-load.js
+++ b/library/js/float-load.js
@@ -16,6 +16,8 @@
 			return;
 		}
 
+		float.css( 'opacity', 1 );
+
 		function reset() {
 			float.removeClass( 'hustle-show' );
 		}

--- a/library/js/inline-load.js
+++ b/library/js/inline-load.js
@@ -19,6 +19,8 @@
 			return;
 		}
 
+		element.css( 'opacity', 1 );
+
 		function reset() {
 			element.removeClass( 'hustle-show' );
 		}

--- a/library/js/popup-load.js
+++ b/library/js/popup-load.js
@@ -16,6 +16,8 @@
 			return;
 		}
 
+		popup.css( 'opacity', 1 );
+
 		function animation() {
 
 			const checkIntro = popup.data( 'intro' );

--- a/library/js/slidein-load.js
+++ b/library/js/slidein-load.js
@@ -16,6 +16,8 @@
 			return;
 		}
 
+		slidein.css( 'opacity', 1 );
+
 		function reset() {
 			slidein.removeClass( 'hustle-show' );
 		}


### PR DESCRIPTION
Related to https://app.asana.com/0/1103916574828896/1113227047924410/f

In frontend, the modules are rendered unstyled, and then the styles and js kick in. This short period is ugly, so we're making the modules' opacity 0 when rendering, and 1 when the js is loaded. Time when the styles are already loaded too so all looks good.

In the repo, this change is in fix/unstyled-modules-onload until the changes are added here in HUI so the modules are not hidden for working in other tasks.