### PR TITLE
Receive translated strings for datepicker

### DIFF
--- a/library/js/datepicker.js
+++ b/library/js/datepicker.js
@@ -8,69 +8,9 @@
 		window.HUI = {};
 	}
 
-	HUI.datepicker = function( el ) {
+	HUI.datepicker = function( el, fullDays, shortDays, minDays, fullMonths, shortMonths ) {
 
 		const input = $( el );
-
-		let fullMonths = [
-			'January',
-			'February',
-			'March',
-			'April',
-			'May',
-			'June',
-			'July',
-			'August',
-			'September',
-			'October',
-			'November',
-			'December'
-		];
-
-		let shortMonths = [
-			'Jan',
-			'Feb',
-			'Mar',
-			'Apr',
-			'May',
-			'Jun',
-			'Jul',
-			'Aug',
-			'Sep',
-			'Oct',
-			'Nov',
-			'Dec'
-		];
-
-		let fullDays = [
-			'Sunday',
-			'Monday',
-			'Tuesday',
-			'Wednesday',
-			'Thursday',
-			'Friday',
-			'Saturday'
-		];
-
-		let minDays = [
-			'Su',
-			'Mo',
-			'Tu',
-			'We',
-			'Th',
-			'Fr',
-			'Sa'
-		];
-
-		let shortDays = [
-			'Sun',
-			'Mon',
-			'Tue',
-			'Wed',
-			'Thu',
-			'Fri',
-			'Sat'
-		];
 
 		$( '.hustle-ui' ).each( function() {
 


### PR DESCRIPTION
Fix for https://app.asana.com/0/1125970634325494/1137501354420337/f

The showcase will probably need to be adjusted after this is merged since the datepicker now expects the string for months and days as parameters.