### PR TITLE
Update/release 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ## [2.1.3](https://github.com/wpmudev/hustle-ui/compare/v2.1.1...v2.1.2) (2023-13-06)
 #### 🐛 Bug Fixes
-- `slide in`
+- `dialog`
   - **fix(dialog):** Unnecessary scrollbar and outline appears in slide in and popup. [#87](https://github.com/wpmudev/hustle-ui/pull/87) ([@creadordev](https://github.com/creadordev))
 
 ## [2.1.2](https://github.com/wpmudev/hustle-ui/compare/v2.1.1...v2.1.2) (2023-09-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org/) for commit guidelines.
 
-## [2.1.2](https://github.com/wpmudev/hustle-ui/compare/v2.1.1...v2.1.2) (2023-06-09)
+## [2.1.3](https://github.com/wpmudev/hustle-ui/compare/v2.1.1...v2.1.2) (2023-13-06)
+#### 🐛 Bug Fixes
+- `slide in`
+  - **fix(dialog):** Unnecessary scrollbar and outline appears in slide in and popup. [#87](https://github.com/wpmudev/hustle-ui/pull/87) ([@creadordev](https://github.com/creadordev))
+
+## [2.1.2](https://github.com/wpmudev/hustle-ui/compare/v2.1.1...v2.1.2) (2023-09-06)
 #### 🐛 Bug Fixes
 - `slide in`
   - **fix(slide in):** Close button not working in safari mobile view. [#85](https://github.com/wpmudev/hustle-ui/pull/85) ([@creadordev](https://github.com/creadordev))


### PR DESCRIPTION
## [2.1.3](https://github.com/wpmudev/hustle-ui/compare/v2.1.1...v2.1.2) (2023-13-06)
#### 🐛 Bug Fixes
- `dialog`
  - **fix(dialog):** Unnecessary scrollbar and outline appears in slide in and popup. [#87](https://github.com/wpmudev/hustle-ui/pull/87) ([@creadordev](https://github.com/creadordev))
